### PR TITLE
Fix "Selecting deleted buffer" in idle timer

### DIFF
--- a/org-count-words.el
+++ b/org-count-words.el
@@ -254,9 +254,11 @@ It defaults to a comma."
                  (lambda (buf)
                    (cancel-timer debounce-timer)
                    (setq debounce-timer nil)
-                   (with-current-buffer buf
-                     (apply orig-fn args)
-                     (force-mode-line-update)))
+                   (when (buffer-live-p buf)
+                     (with-current-buffer buf
+                       (apply orig-fn args)
+                       (force-mode-line-update)))
+                   )
                  (current-buffer))))))))
 
 ;;;###autoload

--- a/org-count-words.el
+++ b/org-count-words.el
@@ -160,7 +160,7 @@ display the word count of the current buffer, and whose `cdr' is
 a format string to display the word count of the selected region
 and the current buffer."
   :group 'org-count-words
-  :type 'cons)
+  :type '(cons string string))
 
 (defvar-local org-count-words-buffer-count 0
   "Keep track of the per-buffer word-count statistics used to


### PR DESCRIPTION
### Description
When using workflows that rapidly create and destroy temporary org buffers (such as `org-roam` dailies), the debounce timer in `org-count-words-debounce` can fire after the buffer has already been killed.

This causes Emacs to throw a `Selecting deleted buffer` error. 

**Fix:** Added a `(buffer-live-p buf)` check inside the timer closure to ensure the buffer still exists before updating.

### Other
During byte-compilation, Emacs throws a warning for `org-count-words-mode-line-format`: `cons without arguments`. 

**Fix:** Explicitly defined the type as `(cons string string)`.

Tested locally and both changes work as expected. Let me know if you need any adjustments!